### PR TITLE
typo fix: second output changed to overflow exist

### DIFF
--- a/Day 17 - Assert Statement/readme.md
+++ b/Day 17 - Assert Statement/readme.md
@@ -76,7 +76,7 @@ as sum = 78 + 84 = 162 is less than or equal to 255.
 when we pass input as 198 and 84 and then run the checkAssert function we get the output as
 
 ```solidity
-0 : string: No Overflow
+0 : string: Overflow exist
 ```
 
 as sum = 198 + 84 = 282 is greater than 255.

--- a/Day 17 - Assert Statement/readme.md
+++ b/Day 17 - Assert Statement/readme.md
@@ -81,6 +81,7 @@ when we pass input as 198 and 84 and then run the checkAssert function we get th
 
 as sum = 198 + 84 = 282 is greater than 255.
 
+> **Note:** The `assert` statement reverts the state. For the second output to be "Overflow exist", the `result` variable must be in its initial `false` state (i.e., `assertStatement` has not been successfully called before).
 ---
 
 [<< Day 16](../Day%2016%20-%20Require%20Statement/readme.md) | [Day 18 >>](../Day%2018%20-%20Revert%20Statement/readme.md)


### PR DESCRIPTION
### Description
Small typo in Day 17 output logic.

### Changes
 I found a small mistake in the Day 17 readme. In the second example, 198+84=282 which is >255, so the assert fails and it should return "Overflow exist" instead of "No Overflow".  Just fixed it to avoid confusion for new learners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Day 17 example output to reflect observed overflow message.
  * Added note explaining that assert reverts state; clarified conditions required for the example’s second output (the tracked flag must remain in its initial state).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->